### PR TITLE
Make VR keyboard Enter submit in V07X menu bridge

### DIFF
--- a/UI/VR/V07X/index.html
+++ b/UI/VR/V07X/index.html
@@ -286,8 +286,22 @@
                 if (key === 'Backspace') {
                     box.value = box.value.slice(0, -1);
                 } else if (key === 'Enter') {
-                    const btn = bridgeIframe.contentDocument.getElementById('send-button');
-                    if (btn) btn.click();
+                    const beforeSubmit = box.value;
+                    const keyDown = new KeyboardEvent('keydown', {
+                        key: 'Enter',
+                        code: 'Enter',
+                        keyCode: 13,
+                        which: 13,
+                        bubbles: true
+                    });
+                    box.dispatchEvent(keyDown);
+
+                    // menu.html handles submission via inline onkeydown, but fall back
+                    // to app.core.handleInput in case synthetic keyboard events are blocked.
+                    const menuWindow = bridgeIframe.contentWindow;
+                    if (box.value === beforeSubmit && menuWindow?.app?.core?.handleInput) {
+                        menuWindow.app.core.handleInput();
+                    }
                 } else {
                     box.value += key;
                 }


### PR DESCRIPTION
### Motivation
- VR keyboard Enter did not reliably submit the in-game menu input across headsets/browsers because the bridge attempted to click a non-existent `#send-button` in the menu iframe.
- The goal is to make Enter behave consistently for the in-VR air keyboard without relying on native OS keyboards or missing DOM elements.

### Description
- Updated `window.sendKeyToMenu` in `UI/VR/V07X/index.html` to dispatch a synthetic `KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13 })` directly to the menu input `#box` when `Enter` is sent.
- Added a fallback that calls `app.core.handleInput()` on the iframe `contentWindow` when the synthetic key dispatch does not change the input value to ensure submission on environments that block synthetic key handling.
- Guarded the fallback so it only runs if the `box.value` remained the same before and after dispatch to avoid duplicate submissions.
- Kept existing `input` event dispatch and `box.focus()` to maintain typing/sync behavior.

### Testing
- Ran `git diff --check` to ensure no leftover whitespace/errors and it succeeded.
- Verified repository state with `git status --short` and inspected the change via `git show --stat`, both commands completed successfully.
- Confirmed the modified file is `UI/VR/V07X/index.html` and the new logic is present; no automated unit tests exist for this UI bridge change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9bc56fc9c8330a9d95ff041410025)