### PR TITLE
Make screensaver opt-in and add input shield to prevent iframe input capture

### DIFF
--- a/UI/VR/V07X/menu.html
+++ b/UI/VR/V07X/menu.html
@@ -189,12 +189,20 @@
                 pointer-events: auto;
             }
 
-            #screensaver-container .screensaver-media {
-                width: 100%;
-                height: 100%;
-                border: none;
-                object-fit: cover;
-            }
+        #screensaver-container .screensaver-media {
+            width: 100%;
+            height: 100%;
+            border: none;
+            object-fit: cover;
+        }
+
+        #screensaver-container .screensaver-input-shield {
+            position: absolute;
+            inset: 0;
+            background: transparent;
+            z-index: 1;
+            pointer-events: auto;
+        }
 
             /* Chat History and Container */
             #chat-wrapper {
@@ -680,6 +688,7 @@
                 getScreensaverConfig: () => {
                     const timeoutSec = parseInt(localStorage.getItem('selectedScreensaverTimeout') || '120', 10);
                     return {
+                        enabled: localStorage.getItem('selectedScreensaverEnabled') === 'true',
                         url: fixPath(localStorage.getItem('selectedScreensaverURL') || localStorage.getItem('selectedBKGURL') || '../squares'),
                         timeoutMs: Math.max(10, isNaN(timeoutSec) ? 120 : timeoutSec) * 1000,
                         behavior: localStorage.getItem('selectedScreensaverResumeBehavior') || 'destroy'
@@ -701,13 +710,17 @@
                         ifr.src = url;
                         container.appendChild(ifr);
                     }
+
+                    const inputShield = document.createElement('div');
+                    inputShield.className = 'screensaver-input-shield';
+                    container.appendChild(inputShield);
                 },
 
                 showScreensaver: () => {
                     const container = document.getElementById('screensaver-container');
                     if (!container || app.screensaverActive) return;
                     const cfg = app.core.getScreensaverConfig();
-                    if (!cfg.url) return;
+                    if (!cfg.enabled || !cfg.url) return;
 
                     if (!container.firstChild || cfg.behavior === 'destroy') {
                         app.core.buildScreensaverContent(container, cfg.url);
@@ -735,6 +748,10 @@
                 registerUserActivity: (source = 'activity') => {
                     clearTimeout(app.screensaverTimer);
                     const cfg = app.core.getScreensaverConfig();
+                    if (!cfg.enabled) {
+                        app.core.hideScreensaver(source);
+                        return;
+                    }
                     app.screensaverTimer = setTimeout(() => app.core.showScreensaver(), cfg.timeoutMs);
                     app.core.hideScreensaver(source);
                 },

--- a/index.html
+++ b/index.html
@@ -196,6 +196,14 @@
                 object-fit: cover;
             }
 
+            #screensaver-container .screensaver-input-shield {
+                position: absolute;
+                inset: 0;
+                background: transparent;
+                z-index: 1;
+                pointer-events: auto;
+            }
+
             /* Chat History and Container */
             #chat-wrapper {
                 position: fixed;
@@ -785,6 +793,7 @@ if ('serviceWorker' in navigator) {
                 getScreensaverConfig: () => {
                     const timeoutSec = parseInt(localStorage.getItem('selectedScreensaverTimeout') || '120', 10);
                     return {
+                        enabled: localStorage.getItem('selectedScreensaverEnabled') === 'true',
                         url: localStorage.getItem('selectedScreensaverURL') || app.config.modules.bg,
                         timeoutMs: Math.max(10, isNaN(timeoutSec) ? 120 : timeoutSec) * 1000,
                         behavior: localStorage.getItem('selectedScreensaverResumeBehavior') || 'destroy'
@@ -806,13 +815,17 @@ if ('serviceWorker' in navigator) {
                         ifr.src = url;
                         container.appendChild(ifr);
                     }
+
+                    const inputShield = document.createElement('div');
+                    inputShield.className = 'screensaver-input-shield';
+                    container.appendChild(inputShield);
                 },
 
                 showScreensaver: () => {
                     const container = document.getElementById('screensaver-container');
                     if (!container || app.screensaverActive) return;
                     const cfg = app.core.getScreensaverConfig();
-                    if (!cfg.url) return;
+                    if (!cfg.enabled || !cfg.url) return;
 
                     if (!container.firstChild || cfg.behavior === 'destroy') {
                         app.core.buildScreensaverContent(container, cfg.url);
@@ -841,6 +854,10 @@ if ('serviceWorker' in navigator) {
                 registerUserActivity: (source = 'activity') => {
                     clearTimeout(app.screensaverTimer);
                     const cfg = app.core.getScreensaverConfig();
+                    if (!cfg.enabled) {
+                        app.core.hideScreensaver(source);
+                        return;
+                    }
                     app.screensaverTimer = setTimeout(() => app.core.showScreensaver(), cfg.timeoutMs);
                     app.core.hideScreensaver(source);
                 },

--- a/settings/index.html
+++ b/settings/index.html
@@ -303,6 +303,13 @@
                         <p style="font-size:0.75rem; opacity:0.75; line-height:1.5;">
                             Screensaver content works like wallpapers, but appears after inactivity and closes when you interact again.
                         </p>
+                        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:12px;">
+                            <span style="font-size:0.85rem">Enable screensaver?</span>
+                            <label class="switch">
+                                <input type="checkbox" id="screensaverenabled">
+                                <span class="slider"></span>
+                            </label>
+                        </div>
                         <div class="grid-2">
                             <button class="setbutton" onclick="document.getElementById('screensaverurl').value='https://76836.github.io/Akari/wallpapers/luna.png'">Luna</button>
                             <button class="setbutton" onclick="document.getElementById('screensaverurl').value='https://76836.github.io/Akari/wallpapers/colors.jpg'">Colors</button>
@@ -412,6 +419,7 @@
             document.getElementById('screensaverurl').value = localStorage.getItem('selectedScreensaverURL') || "";
             document.getElementById('screensavertimeout').value = localStorage.getItem('selectedScreensaverTimeout') || "120";
             document.getElementById('screensaverbehavior').value = localStorage.getItem('selectedScreensaverResumeBehavior') || "destroy";
+            document.getElementById('screensaverenabled').checked = localStorage.getItem('selectedScreensaverEnabled') === "true";
 
             document.getElementById('toggle_avatar').checked = (avatar !== "off" && avatar !== null && avatar !== "");
             document.getElementById('toggle_wake').checked = (wake !== "off" && wake !== null && wake !== "");
@@ -472,6 +480,7 @@
             const timeoutRaw = parseInt(document.getElementById('screensavertimeout').value, 10);
             const timeout = Math.max(10, isNaN(timeoutRaw) ? 120 : timeoutRaw);
             const behavior = document.getElementById('screensaverbehavior').value || 'destroy';
+            const enabled = document.getElementById('screensaverenabled').checked;
 
             if (url) {
                 localStorage.setItem('selectedScreensaverURL', url);
@@ -481,6 +490,7 @@
 
             localStorage.setItem('selectedScreensaverTimeout', String(timeout));
             localStorage.setItem('selectedScreensaverResumeBehavior', behavior);
+            localStorage.setItem('selectedScreensaverEnabled', enabled ? 'true' : 'false');
             alert("Screensaver settings saved.");
         }
 


### PR DESCRIPTION
### Motivation
- Prevent users from being trapped by iframe-based screensavers that capture input and block interactions by ensuring screensavers are opt-in and can't receive direct user events.
- Provide a simple, robust approach so activity (clicks/keys/wake words) reliably dismisses the screensaver.

### Description
- Add a persistent opt-in flag `selectedScreensaverEnabled` exposed via the settings UI and read by runtime via `getScreensaverConfig` so screensavers are disabled by default unless explicitly enabled in settings. 
- Inject a transparent overlay element `.screensaver-input-shield` into the screensaver container so embedded iframes/images cannot intercept pointer/keyboard events. 
- Update screensaver lifecycle logic (`showScreensaver`, `buildScreensaverContent`, and `registerUserActivity`) to respect the `enabled` flag and to append/remove the input shield when building screensaver content. 
- Update the settings UI (`settings/index.html`) to add an `Enable screensaver?` checkbox (`#screensaverenabled`) and persist its value in `localStorage` via `saveScreensaverSettings`.

### Testing
- Ran `git diff --check` to validate no whitespace/diff issues and it completed successfully. 
- Ran `git status --short` to confirm changed files are staged and it completed successfully. 
- Performed a commit of the changes which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a77325c883308d51abcb5a090259)