### PR TITLE
Add automata-native AkariNet WebUI experiment

### DIFF
--- a/UI/WebUI/automata-app.js
+++ b/UI/WebUI/automata-app.js
@@ -1,0 +1,134 @@
+import { createAutomataRuntime } from './automata-core.js';
+import { installProviderAutomata } from './automata-providers.js';
+import { installAudioAutomata } from './automata-audio.js';
+
+const runtime = createAutomataRuntime();
+hydrateSettings(runtime);
+installProviderAutomata(runtime);
+installAudioAutomata(runtime);
+installUiAutomata(runtime);
+
+function hydrateSettings(runtimeApi) {
+    try {
+        const raw = localStorage.getItem('webui.automata.settings');
+        if (!raw) {
+            return;
+        }
+        const parsed = JSON.parse(raw);
+        runtimeApi.updateSettings({
+            pollinationsModel: parsed?.models?.pollinationsModel,
+            geminiModel: parsed?.models?.geminiModel,
+            voice: parsed?.voice,
+            automataEnabled: {
+                ...runtimeApi.state.memory.settings.automataEnabled,
+                ...(parsed?.automataEnabled || {})
+            }
+        });
+    } catch {
+        runtimeApi.emit('assistant.error', { message: 'Failed to load WebUI settings.' });
+    }
+}
+
+function installUiAutomata(runtimeApi) {
+    const log = document.getElementById('chat-log');
+    const form = document.getElementById('chat-form');
+    const input = document.getElementById('chat-input');
+    const list = document.getElementById('automata-list');
+
+    function print(role, text) {
+        const node = document.createElement('div');
+        node.className = `message ${role}`;
+        node.textContent = `${role.toUpperCase()}: ${text}`;
+        log.appendChild(node);
+        log.scrollTop = log.scrollHeight;
+    }
+
+    runtimeApi.register('ui.automata', {
+        name: 'UI Automata',
+        version: '1.0.0',
+        description: 'Manages UI events and automata visualization.',
+        events: ['ui.message', 'assistant.reply', 'assistant.error'],
+        async handle({ eventName, payload }) {
+            if (!runtimeApi.state.memory.settings.automataEnabled['ui.automata']) {
+                return;
+            }
+            if (eventName === 'ui.message') {
+                print(payload.role || 'system', payload.text || '');
+                return;
+            }
+
+            if (eventName === 'assistant.reply') {
+                print('assistant', payload.text || '');
+                return;
+            }
+
+            if (eventName === 'assistant.error') {
+                print('system', `Error: ${payload.message || 'unknown error'}`);
+            }
+        }
+    });
+
+    runtimeApi.on('ui.message', 'ui.automata');
+    runtimeApi.on('assistant.reply', 'ui.automata');
+    runtimeApi.on('assistant.error', 'ui.automata');
+
+    function renderAutomataList() {
+        list.innerHTML = '';
+        Object.values(runtimeApi.state.automata).forEach((item) => {
+            const card = document.createElement('div');
+            card.className = 'automata-item';
+            card.innerHTML = `
+                <div class="name">${item.name}</div>
+                <div class="meta">${item.id} · v${item.version}</div>
+                <div class="meta">${item.description}</div>
+            `;
+            list.appendChild(card);
+        });
+    }
+
+    function sendPrompt(text) {
+        runtimeApi.addMessage('user', text);
+        runtimeApi.emit('ui.message', { role: 'user', text });
+        runtimeApi.emit('assistant.request', { source: 'ui.form' });
+    }
+
+    form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const value = input.value.trim();
+        if (!value) {
+            return;
+        }
+        input.value = '';
+        sendPrompt(value);
+    });
+
+    document.getElementById('provider-pollinations').addEventListener('click', () => {
+        runtimeApi.setProvider('pollinations');
+        runtimeApi.emit('ui.message', { role: 'system', text: 'Provider switched to Pollinations.' });
+    });
+
+    document.getElementById('provider-gemini').addEventListener('click', () => {
+        runtimeApi.setProvider('gemini');
+        runtimeApi.emit('ui.message', { role: 'system', text: 'Provider switched to Gemini.' });
+    });
+
+    document.getElementById('speak-last').addEventListener('click', () => {
+        runtimeApi.emit('audio.tts.speak', { text: runtimeApi.state.memory.lastReply });
+    });
+
+    document.getElementById('open-settings').addEventListener('click', () => {
+        window.location.href = './settings.html';
+    });
+
+    renderAutomataList();
+    runtimeApi.emit('ui.message', {
+        role: 'system',
+        text: 'AkariNet WebUI loaded. This experiment is fully automata-native.'
+    });
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.key.toLowerCase() === 'l' && event.altKey) {
+        runtime.emit('audio.listen.start', { source: 'keyboard.alt+l' });
+    }
+});

--- a/UI/WebUI/automata-audio.js
+++ b/UI/WebUI/automata-audio.js
@@ -1,0 +1,87 @@
+export function installAudioAutomata(runtime) {
+    runtime.register('audio.console.automata', {
+        name: 'Audio Console Automata',
+        version: '1.0.0',
+        description: 'Simple automata audio console integration using browser SpeechRecognition.',
+        events: ['audio.listen.start'],
+        async handle({ eventName }) {
+            if (!runtime.state.memory.settings.automataEnabled['audio.console.automata']) {
+                return;
+            }
+            if (eventName !== 'audio.listen.start') {
+                return;
+            }
+
+            const Recognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+            if (!Recognition) {
+                await runtime.emit('assistant.error', { message: 'SpeechRecognition is not available in this browser.' });
+                return;
+            }
+
+            const rec = new Recognition();
+            rec.lang = 'en-US';
+            rec.maxAlternatives = 1;
+            rec.interimResults = false;
+
+            rec.onresult = async (evt) => {
+                const text = evt.results?.[0]?.[0]?.transcript || '';
+                if (!text.trim()) {
+                    return;
+                }
+                runtime.addMessage('user', text);
+                await runtime.emit('ui.message', { role: 'user', text });
+                await runtime.emit('assistant.request', { source: 'audio.console.automata' });
+            };
+
+            rec.onerror = async () => {
+                await runtime.emit('assistant.error', { message: 'Speech recognition error.' });
+            };
+
+            rec.start();
+            await runtime.emit('ui.message', { role: 'system', text: 'Listening...' });
+        }
+    });
+
+    runtime.on('audio.listen.start', 'audio.console.automata');
+
+    runtime.register('kitten.tts.automata', {
+        name: 'KittenTTS Automata',
+        version: '1.0.0',
+        description: 'Automata voice output with SpeechSynthesis fallback for KittenTTS flow.',
+        events: ['audio.tts.speak'],
+        async handle({ eventName, payload }) {
+            if (!runtime.state.memory.settings.automataEnabled['kitten.tts.automata']) {
+                return;
+            }
+            if (eventName !== 'audio.tts.speak') {
+                return;
+            }
+
+            const text = payload?.text || runtime.state.memory.lastReply;
+            if (!text) {
+                return;
+            }
+
+            if (!window.speechSynthesis) {
+                await runtime.emit('assistant.error', { message: 'SpeechSynthesis is not available in this browser.' });
+                return;
+            }
+
+            const utterance = new SpeechSynthesisUtterance(text);
+            const pref = runtime.state.memory.settings.voice;
+            const voices = window.speechSynthesis.getVoices();
+
+            if (pref && pref !== 'default') {
+                const match = voices.find((v) => v.name === pref);
+                if (match) {
+                    utterance.voice = match;
+                }
+            }
+
+            window.speechSynthesis.cancel();
+            window.speechSynthesis.speak(utterance);
+        }
+    });
+
+    runtime.on('audio.tts.speak', 'kitten.tts.automata');
+}

--- a/UI/WebUI/automata-core.js
+++ b/UI/WebUI/automata-core.js
@@ -1,0 +1,83 @@
+export function createAutomataRuntime() {
+    const state = {
+        automata: {},
+        subscriptions: {},
+        memory: {
+            provider: 'pollinations',
+            history: [],
+            lastReply: '',
+            settings: {
+                pollinationsModel: 'openai-large',
+                geminiModel: 'gemini-2.0-flash',
+                maxHistory: 20,
+                voice: 'default',
+                automataEnabled: {
+                    'pollinations.automata': true,
+                    'gemini.automata': true,
+                    'audio.console.automata': true,
+                    'kitten.tts.automata': true,
+                    'ui.automata': true
+                }
+            }
+        }
+    };
+
+    function register(id, def) {
+        state.automata[id] = {
+            id,
+            name: def.name || id,
+            version: def.version || '0.1.0',
+            description: def.description || '',
+            handle: def.handle || (() => {}),
+            events: def.events || []
+        };
+    }
+
+    function on(eventName, automataId) {
+        if (!state.subscriptions[eventName]) {
+            state.subscriptions[eventName] = [];
+        }
+        state.subscriptions[eventName].push(automataId);
+    }
+
+    async function emit(eventName, payload) {
+        const listeners = state.subscriptions[eventName] || [];
+        for (const id of listeners) {
+            const unit = state.automata[id];
+            if (!unit) {
+                continue;
+            }
+            await unit.handle({ eventName, payload, runtime: api });
+        }
+    }
+
+    function addMessage(role, text) {
+        state.memory.history.push({ role, text, time: Date.now() });
+        if (state.memory.history.length > state.memory.settings.maxHistory) {
+            state.memory.history = state.memory.history.slice(-state.memory.settings.maxHistory);
+        }
+    }
+
+    function setProvider(provider) {
+        state.memory.provider = provider;
+    }
+
+    function updateSettings(next) {
+        const filtered = Object.fromEntries(
+            Object.entries(next || {}).filter(([, value]) => value !== undefined)
+        );
+        state.memory.settings = { ...state.memory.settings, ...filtered };
+    }
+
+    const api = {
+        state,
+        register,
+        on,
+        emit,
+        addMessage,
+        setProvider,
+        updateSettings
+    };
+
+    return api;
+}

--- a/UI/WebUI/automata-providers.js
+++ b/UI/WebUI/automata-providers.js
@@ -1,0 +1,108 @@
+function makeBody(messages, model) {
+    return {
+        model,
+        messages: messages.map((item) => ({
+            role: item.role,
+            content: item.text
+        }))
+    };
+}
+
+async function requestPollinations(runtime) {
+    const body = makeBody(runtime.state.memory.history, runtime.state.memory.settings.pollinationsModel);
+    const response = await fetch('https://text.pollinations.ai/openai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+        throw new Error('Pollinations request failed');
+    }
+
+    const data = await response.json();
+    return data?.choices?.[0]?.message?.content || 'No response text from Pollinations.';
+}
+
+async function requestGemini(runtime) {
+    const key = localStorage.getItem('webui.gemini.key') || '';
+    if (!key) {
+        throw new Error('Gemini key missing. Add it in Automata Settings.');
+    }
+
+    const prompt = runtime.state.memory.history
+        .map((item) => `${item.role.toUpperCase()}: ${item.text}`)
+        .join('\n');
+
+    const model = runtime.state.memory.settings.geminiModel;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(key)}`;
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }]
+        })
+    });
+
+    if (!response.ok) {
+        throw new Error('Gemini request failed');
+    }
+
+    const data = await response.json();
+    return data?.candidates?.[0]?.content?.parts?.[0]?.text || 'No response text from Gemini.';
+}
+
+export function installProviderAutomata(runtime) {
+    runtime.register('pollinations.automata', {
+        name: 'Pollinations Automata',
+        version: '1.0.0',
+        description: 'Automata wrapper around Pollinations AI text endpoint.',
+        events: ['assistant.request'],
+        async handle({ eventName }) {
+            if (!runtime.state.memory.settings.automataEnabled['pollinations.automata']) {
+                return;
+            }
+            if (eventName !== 'assistant.request' || runtime.state.memory.provider !== 'pollinations') {
+                return;
+            }
+
+            try {
+                const text = await requestPollinations(runtime);
+                runtime.state.memory.lastReply = text;
+                runtime.addMessage('assistant', text);
+                await runtime.emit('assistant.reply', { text, provider: 'pollinations' });
+            } catch (error) {
+                await runtime.emit('assistant.error', { message: error.message });
+            }
+        }
+    });
+
+    runtime.on('assistant.request', 'pollinations.automata');
+
+    runtime.register('gemini.automata', {
+        name: 'Gemini Automata',
+        version: '1.0.0',
+        description: 'Automata wrapper around Gemini generateContent API.',
+        events: ['assistant.request'],
+        async handle({ eventName }) {
+            if (!runtime.state.memory.settings.automataEnabled['gemini.automata']) {
+                return;
+            }
+            if (eventName !== 'assistant.request' || runtime.state.memory.provider !== 'gemini') {
+                return;
+            }
+
+            try {
+                const text = await requestGemini(runtime);
+                runtime.state.memory.lastReply = text;
+                runtime.addMessage('assistant', text);
+                await runtime.emit('assistant.reply', { text, provider: 'gemini' });
+            } catch (error) {
+                await runtime.emit('assistant.error', { message: error.message });
+            }
+        }
+    });
+
+    runtime.on('assistant.request', 'gemini.automata');
+}

--- a/UI/WebUI/index.html
+++ b/UI/WebUI/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AkariNet WebUI (Automata Native)</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <main class="shell">
+        <header class="topbar">
+            <div>
+                <h1>AkariNet WebUI</h1>
+                <p class="subtitle">Automata-native assistant experiment</p>
+            </div>
+            <div class="topbar-actions">
+                <button id="open-settings" class="btn">Automata Settings</button>
+            </div>
+        </header>
+
+        <section class="layout">
+            <aside class="panel automata-panel">
+                <h2>Automata Graph</h2>
+                <p>All modules communicate through automata events only.</p>
+                <div id="automata-list" class="automata-list"></div>
+            </aside>
+
+            <section class="panel chat-panel">
+                <div id="chat-log" class="chat-log"></div>
+                <form id="chat-form" class="chat-form">
+                    <input id="chat-input" type="text" autocomplete="off" placeholder="Type a prompt for AkariNet..." required>
+                    <button type="submit" class="btn btn-primary">Send</button>
+                </form>
+                <div class="quick-row">
+                    <button id="provider-pollinations" class="btn">Use Pollinations</button>
+                    <button id="provider-gemini" class="btn">Use Gemini</button>
+                    <button id="speak-last" class="btn">Speak Last Reply</button>
+                </div>
+            </section>
+        </section>
+    </main>
+
+    <script type="module" src="./automata-app.js"></script>
+</body>
+</html>

--- a/UI/WebUI/settings.html
+++ b/UI/WebUI/settings.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AkariNet WebUI Settings</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <main class="settings-shell">
+        <header class="topbar">
+            <div>
+                <h1>WebUI Settings</h1>
+                <p class="subtitle">Simple controls inspired by earlier Akari layouts.</p>
+            </div>
+            <button id="back-home" class="btn">Back to WebUI</button>
+        </header>
+
+        <section class="settings-grid">
+            <article class="card">
+                <h2>Provider Models</h2>
+                <label for="pollinations-model">Pollinations model</label>
+                <input id="pollinations-model" type="text" value="openai-large">
+                <label for="gemini-model">Gemini model</label>
+                <input id="gemini-model" type="text" value="gemini-2.0-flash">
+                <button id="save-models" class="btn btn-primary">Save Models</button>
+            </article>
+
+            <article class="card">
+                <h2>Gemini Key</h2>
+                <label for="gemini-key">API key</label>
+                <input id="gemini-key" type="password" placeholder="AIza...">
+                <p class="small">Stored in localStorage as webui.gemini.key.</p>
+                <button id="save-key" class="btn btn-primary">Save Key</button>
+            </article>
+
+            <article class="card">
+                <h2>Audio / KittenTTS</h2>
+                <label for="voice-select">Voice profile</label>
+                <select id="voice-select">
+                    <option value="default">default</option>
+                </select>
+                <button id="refresh-voices" class="btn">Refresh Voices</button>
+                <button id="save-audio" class="btn btn-primary">Save Audio</button>
+            </article>
+
+            <article class="card">
+                <h2>Automata Manager</h2>
+                <p class="small">Enable or disable automata modules for testing.</p>
+                <div id="automata-manager"></div>
+                <button id="save-automata" class="btn btn-primary">Save Automata States</button>
+            </article>
+        </section>
+
+        <section class="card" style="margin-top:12px;">
+            <h2>Status</h2>
+            <pre id="status-box">Ready.</pre>
+        </section>
+    </main>
+
+    <script type="module" src="./settings.js"></script>
+</body>
+</html>

--- a/UI/WebUI/settings.js
+++ b/UI/WebUI/settings.js
@@ -1,0 +1,143 @@
+const defaults = {
+    automataEnabled: {
+        'pollinations.automata': true,
+        'gemini.automata': true,
+        'audio.console.automata': true,
+        'kitten.tts.automata': true,
+        'ui.automata': true
+    },
+    models: {
+        pollinationsModel: 'openai-large',
+        geminiModel: 'gemini-2.0-flash'
+    },
+    voice: 'default'
+};
+
+const storeKey = 'webui.automata.settings';
+const settings = loadSettings();
+
+bindInitialState();
+attachEvents();
+renderAutomataManager();
+renderVoices();
+
+function loadSettings() {
+    try {
+        const raw = localStorage.getItem(storeKey);
+        if (!raw) {
+            return structuredClone(defaults);
+        }
+        const parsed = JSON.parse(raw);
+        return {
+            automataEnabled: { ...defaults.automataEnabled, ...(parsed.automataEnabled || {}) },
+            models: { ...defaults.models, ...(parsed.models || {}) },
+            voice: parsed.voice || 'default'
+        };
+    } catch {
+        return structuredClone(defaults);
+    }
+}
+
+function saveSettings() {
+    localStorage.setItem(storeKey, JSON.stringify(settings));
+}
+
+function setStatus(text) {
+    document.getElementById('status-box').textContent = text;
+}
+
+function bindInitialState() {
+    document.getElementById('pollinations-model').value = settings.models.pollinationsModel;
+    document.getElementById('gemini-model').value = settings.models.geminiModel;
+    document.getElementById('voice-select').value = settings.voice;
+}
+
+function attachEvents() {
+    document.getElementById('back-home').addEventListener('click', () => {
+        window.location.href = './index.html';
+    });
+
+    document.getElementById('save-models').addEventListener('click', () => {
+        settings.models.pollinationsModel = document.getElementById('pollinations-model').value.trim() || defaults.models.pollinationsModel;
+        settings.models.geminiModel = document.getElementById('gemini-model').value.trim() || defaults.models.geminiModel;
+        saveSettings();
+        setStatus('Models saved.');
+    });
+
+    document.getElementById('save-key').addEventListener('click', () => {
+        const key = document.getElementById('gemini-key').value.trim();
+        if (!key) {
+            setStatus('Gemini key is empty.');
+            return;
+        }
+        localStorage.setItem('webui.gemini.key', key);
+        setStatus('Gemini key saved.');
+    });
+
+    document.getElementById('refresh-voices').addEventListener('click', () => {
+        renderVoices();
+        setStatus('Voices refreshed.');
+    });
+
+    document.getElementById('save-audio').addEventListener('click', () => {
+        settings.voice = document.getElementById('voice-select').value;
+        saveSettings();
+        setStatus('Audio settings saved.');
+    });
+
+    document.getElementById('save-automata').addEventListener('click', () => {
+        const checks = document.querySelectorAll('[data-automata-id]');
+        checks.forEach((node) => {
+            settings.automataEnabled[node.dataset.automataId] = node.checked;
+        });
+        saveSettings();
+        setStatus('Automata manager settings saved.');
+    });
+}
+
+function renderAutomataManager() {
+    const holder = document.getElementById('automata-manager');
+    holder.innerHTML = '';
+
+    Object.keys(settings.automataEnabled).forEach((id) => {
+        const row = document.createElement('label');
+        row.style.display = 'flex';
+        row.style.alignItems = 'center';
+        row.style.gap = '8px';
+        row.style.marginBottom = '8px';
+
+        const check = document.createElement('input');
+        check.type = 'checkbox';
+        check.dataset.automataId = id;
+        check.checked = !!settings.automataEnabled[id];
+        check.style.width = 'auto';
+
+        const text = document.createElement('span');
+        text.textContent = id;
+
+        row.appendChild(check);
+        row.appendChild(text);
+        holder.appendChild(row);
+    });
+}
+
+function renderVoices() {
+    const select = document.getElementById('voice-select');
+    const saved = settings.voice;
+    const synth = window.speechSynthesis;
+    const voices = synth ? synth.getVoices() : [];
+
+    select.innerHTML = '<option value="default">default</option>';
+    voices.forEach((voice) => {
+        const opt = document.createElement('option');
+        opt.value = voice.name;
+        opt.textContent = `${voice.name} (${voice.lang})`;
+        select.appendChild(opt);
+    });
+
+    if ([...select.options].some((o) => o.value === saved)) {
+        select.value = saved;
+    }
+}
+
+window.speechSynthesis?.addEventListener('voiceschanged', renderVoices);

--- a/UI/WebUI/styles.css
+++ b/UI/WebUI/styles.css
@@ -1,0 +1,201 @@
+:root {
+    color-scheme: dark;
+    --bg: #0a0a0f;
+    --bg-soft: #12121a;
+    --line: #2b2b38;
+    --text: #f2f2f5;
+    --muted: #a7a7ba;
+    --accent: #8f62ff;
+    --accent-soft: #2a1d4f;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: radial-gradient(circle at top, #1d1b2f, var(--bg));
+    color: var(--text);
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.shell {
+    max-width: 1100px;
+    margin: 0 auto;
+    min-height: 100vh;
+    padding: 16px;
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.topbar h1 {
+    margin: 0;
+    font-size: 28px;
+}
+
+.subtitle {
+    margin: 4px 0 0;
+    color: var(--muted);
+}
+
+.layout {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 320px 1fr;
+}
+
+.panel {
+    background: rgba(15, 15, 23, 0.9);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 12px;
+}
+
+.automata-panel h2,
+.chat-panel h2 {
+    margin-top: 0;
+}
+
+.automata-list {
+    display: grid;
+    gap: 8px;
+}
+
+.automata-item {
+    border: 1px solid var(--line);
+    background: var(--bg-soft);
+    border-radius: 8px;
+    padding: 8px;
+}
+
+.automata-item .name {
+    font-weight: 700;
+}
+
+.automata-item .meta {
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.chat-log {
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: #090910;
+    min-height: 350px;
+    max-height: 62vh;
+    overflow-y: auto;
+    padding: 10px;
+}
+
+.message {
+    padding: 8px 10px;
+    border-radius: 8px;
+    margin-bottom: 8px;
+    border: 1px solid #232332;
+    white-space: pre-wrap;
+}
+
+.message.user {
+    background: #161629;
+}
+
+.message.assistant {
+    background: #0f1a12;
+}
+
+.message.system {
+    background: var(--accent-soft);
+}
+
+.chat-form {
+    margin-top: 10px;
+    display: flex;
+    gap: 8px;
+}
+
+.chat-form input {
+    flex: 1;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: #07070f;
+    color: var(--text);
+    font-size: 16px;
+    padding: 10px;
+}
+
+.quick-row {
+    margin-top: 10px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.btn {
+    border: 1px solid #3a3a4f;
+    border-radius: 8px;
+    background: #151525;
+    color: var(--text);
+    padding: 9px 12px;
+    cursor: pointer;
+}
+
+.btn-primary {
+    border-color: #6f4de7;
+    background: linear-gradient(180deg, #6f4de7, #5638be);
+}
+
+.settings-shell {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 16px;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 12px;
+}
+
+.card {
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: rgba(15, 15, 23, 0.92);
+    padding: 12px;
+}
+
+label {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    border: 1px solid #333348;
+    border-radius: 8px;
+    background: #0a0a13;
+    color: var(--text);
+    padding: 8px;
+}
+
+.small {
+    color: var(--muted);
+    font-size: 12px;
+}
+
+@media (max-width: 900px) {
+    .layout {
+        grid-template-columns: 1fr;
+    }
+}

--- a/app.html
+++ b/app.html
@@ -198,6 +198,13 @@
                 image: './images/logo512.png'
             },
             {
+                url: './UI/WebUI/index.html',
+                name: 'AkariNet WebUI Automata',
+                description: 'A fully automata-native AkariNet experiment with modular provider and audio automata.',
+                badge: 'Automata Native',
+                image: './images/logo512.png'
+            },
+            {
                 url: './mini',
                 name: 'Quick Assistant',
                 description: 'Lightweight and fast (depreciated)',


### PR DESCRIPTION
### Motivation
- Provide a clean, Automata-native rewrite of an AkariNet UI experiment so modules communicate via a lightweight event-based automata runtime instead of legacy interconnected scripts.
- Offer built-in provider automata for Pollinations and Gemini and automata-native audio (microphone input + TTS) to simplify integrations and make testing modular.
- Expose a minimal settings UI with an Automata Manager so modules can be enabled/disabled and provider credentials/models can be configured.

### Description
- Added a self-contained WebUI under `UI/WebUI` including `index.html`, `styles.css`, a small orchestrator (`automata-app.js`), an automata runtime (`automata-core.js`), provider automata (`automata-providers.js`), audio automata (`automata-audio.js`), and settings pages (`settings.html`, `settings.js`).
- Implemented an event-driven `createAutomataRuntime()` that supports `register`, `on`, `emit`, `addMessage`, `setProvider`, and `updateSettings` to make all modules Automata-native and independent of legacy classes.
- Implemented `pollinations.automata` and `gemini.automata` provider modules and `audio.console.automata` plus `kitten.tts.automata` for input/output, with Gemini key stored in `localStorage` and provider/models selectable from the settings UI.
- Updated `app.html` as the only change outside `UI/WebUI` to add the new "AkariNet WebUI Automata" option in the UI chooser; automata modules can be toggled via the Automata Manager and settings are persisted under `webui.automata.settings`.

### Testing
- Verified JavaScript syntax with `node --check UI/WebUI/automata-app.js && node --check UI/WebUI/automata-audio.js && node --check UI/WebUI/automata-core.js && node --check UI/WebUI/automata-providers.js && node --check UI/WebUI/settings.js` and all checks passed.
- Confirmed file lengths with `wc -l UI/WebUI/* app.html` to ensure no single file in `UI/WebUI` exceeds 800 lines and that new files were created as expected.
- Performed a smoke-run of the UI wiring by loading the WebUI entry and confirming the automata list and basic UI actions (provider switch, speak-last, open settings) emit the expected automata events in the runtime (manual runtime verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed358af1e88330b352995578290730)