### PR TITLE
Add real-time automata Task Manager sidebar to WebUI

### DIFF
--- a/UI/WebUI/index.html
+++ b/UI/WebUI/index.html
@@ -164,6 +164,11 @@
             text-align: center; line-height: 30px; font-size: large; position: fixed; top: 7px; right: 7px;
             width: 50px; border: 2px solid black; z-index: 21; cursor: pointer;
         }
+        .button-manager {
+            padding: 5px 10px; border-radius: 20px; background-color: #111111; color: #6ce8ff;
+            text-align: center; line-height: 30px; font-size: large; position: fixed; top: 7px; right: 68px;
+            width: 50px; border: 2px solid black; z-index: 21; cursor: pointer;
+        }
 
         .button-long, .toggle-btn {
             background: crimson; border: 2px solid #333; color: white; padding: 10px 20px; border-radius: 20px;
@@ -183,6 +188,33 @@
             position: fixed; top: 88vh; left: 7vw; background: darkred; color: white; border: 2px solid red;
             padding: 10px; border-radius: 8px; width: 86vw; z-index: 101;
         }
+
+        #task-manager-sidebar {
+            position: fixed; top: 0; right: 0; width: min(460px, 95vw); height: 100vh;
+            background: rgba(10, 10, 12, 0.92); backdrop-filter: blur(12px);
+            border-left: 2px solid rgba(108, 232, 255, 0.25);
+            transform: translateX(100%); transition: transform 0.25s ease;
+            z-index: 160; display: flex; flex-direction: column;
+        }
+        #task-manager-sidebar.open { transform: translateX(0); }
+        .tm-header { padding: 14px 16px; border-bottom: 1px solid #1c2a33; display: flex; justify-content: space-between; align-items: center; }
+        .tm-title { font-size: 1rem; color: #6ce8ff; }
+        .tm-body { padding: 14px 16px; overflow-y: auto; display: flex; flex-direction: column; gap: 14px; }
+        .tm-card { border: 1px solid #212f3a; border-radius: 10px; padding: 12px; background: rgba(255, 255, 255, 0.03); }
+        .tm-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; font-size: 0.8rem; color: #9fb5c2; }
+        .tm-btn { background: #123143; border: 1px solid #2f6f8f; color: #d2f6ff; border-radius: 8px; padding: 8px; cursor: pointer; font-family: inherit; }
+        .tm-btn.danger { background: #441717; border-color: #b64d4d; color: #ffd0d0; }
+        .tm-btn.subtle { background: #1d1d1d; border-color: #555; color: #ddd; }
+        .tm-row { display: flex; gap: 8px; }
+        .tm-input, .tm-select {
+            width: 100%; box-sizing: border-box; border-radius: 8px; border: 1px solid #344652; background: #050709;
+            color: #fff; padding: 8px; font-family: inherit;
+        }
+        .tm-list { display: flex; flex-direction: column; gap: 8px; max-height: 300px; overflow-y: auto; }
+        .tm-item { border: 1px solid #2a3640; border-radius: 8px; padding: 8px; background: rgba(0, 0, 0, 0.2); }
+        .tm-meta { color: #9fb5c2; font-size: 0.75rem; margin-top: 4px; }
+        .tm-eventlog { font-family: monospace; font-size: 0.75rem; max-height: 180px; overflow-y: auto; color: #a8ecff; white-space: pre-wrap; }
+        .tm-pill { display:inline-block; border-radius: 999px; padding: 2px 8px; font-size: 0.72rem; background: #21313a; color:#9be8ff; margin-left: 6px; }
     </style>
 </head>
 <body>
@@ -208,9 +240,57 @@
 
     <div id="status-area" style="position: fixed; bottom: 80px; left: 20px; color: #888; z-index: 51;"></div>
     <div id="window-layer"></div>
+    <aside id="task-manager-sidebar" aria-label="Task manager">
+        <div class="tm-header">
+            <div class="tm-title">Task Manager <span id="tm-live-count" class="tm-pill">0 online</span></div>
+            <button class="tm-btn subtle" onclick="window.toggleTaskManager(false)">Close</button>
+        </div>
+        <div class="tm-body">
+            <div class="tm-card">
+                <div class="tm-grid">
+                    <div>Total Loaded: <b id="tm-stat-loaded">0</b></div>
+                    <div>Blacklisted: <b id="tm-stat-blacklisted">0</b></div>
+                    <div>Packages: <b id="tm-stat-packages">0</b></div>
+                    <div>Conflicts: <b id="tm-stat-conflicts">0</b></div>
+                </div>
+                <div class="tm-row" style="margin-top:8px;">
+                    <button class="tm-btn" onclick="window.taskManagerRefresh()">Refresh</button>
+                    <button class="tm-btn" onclick="window.taskManagerReloadAll()">Reload Packages</button>
+                    <button class="tm-btn danger" onclick="window.taskManagerShutdownAll()">Shutdown All</button>
+                </div>
+            </div>
+
+            <div class="tm-card">
+                <div style="font-size:0.85rem; margin-bottom:8px;">Package URLs</div>
+                <div class="tm-row">
+                    <input class="tm-input" id="tm-new-url" placeholder="https://.../package.atpk">
+                    <button class="tm-btn" onclick="window.taskManagerAddUrl()">Add</button>
+                </div>
+                <div id="tm-url-list" class="tm-list" style="margin-top:8px;"></div>
+            </div>
+
+            <div class="tm-card">
+                <div style="font-size:0.85rem; margin-bottom:8px;">Automata Runtime</div>
+                <div class="tm-row" style="margin-bottom:8px;">
+                    <select id="tm-sort" class="tm-select" onchange="window.taskManagerRefresh()">
+                        <option value="priority">Sort: Priority</option>
+                        <option value="name">Sort: Name</option>
+                        <option value="source">Sort: Source URL</option>
+                    </select>
+                </div>
+                <div id="tm-automata-list" class="tm-list"></div>
+            </div>
+
+            <div class="tm-card">
+                <div style="font-size:0.85rem; margin-bottom:8px;">Runtime Events</div>
+                <div id="tm-event-log" class="tm-eventlog"></div>
+            </div>
+        </div>
+    </aside>
 
     <div class="controls">
         <button class="button-menu" onclick="window.newwindow('settings.html')">⁝</button>
+        <button class="button-manager" onclick="window.toggleTaskManager()">⚙</button>
         <button class="toggle-btn" id="chatToggle" onclick="window.toggleChat()">+</button>
         <button class="button-long" id="micbutton" onclick="window.toggleVoice()">voice</button>
         <input type="text" id="box" class="box" placeholder="What's up?" onkeydown="if(event.keyCode==13) window.handleInput()">

--- a/UI/WebUI/index.js
+++ b/UI/WebUI/index.js
@@ -193,6 +193,213 @@
         }
     };
 
+    // 3.5 Task Manager Sidebar
+    const STORAGE_URLS = 'akari:automata_urls';
+    const STORAGE_BLACKLIST = 'akari:automata_blacklist';
+    const tmState = { events: [] };
+
+    function readJSONList(key) {
+        try {
+            const val = JSON.parse(localStorage.getItem(key) || '[]');
+            return Array.isArray(val) ? val : [];
+        } catch {
+            return [];
+        }
+    }
+
+    function writeJSONList(key, values) {
+        localStorage.setItem(key, JSON.stringify(Array.isArray(values) ? values : []));
+    }
+
+    function tmLog(line) {
+        tmState.events.unshift(`[${new Date().toLocaleTimeString()}] ${line}`);
+        tmState.events = tmState.events.slice(0, 60);
+        const logEl = document.getElementById('tm-event-log');
+        if (logEl) logEl.textContent = tmState.events.join('\n');
+    }
+
+    function formatMeta(a) {
+        const tags = [];
+        if (a.respondsto?.length) tags.push(`responds: ${a.respondsto.join(', ')}`);
+        if (a.controls?.length) tags.push(`controls: ${a.controls.join(', ')}`);
+        if (a.dependencies?.length) tags.push(`deps: ${a.dependencies.join(', ')}`);
+        return tags.join(' | ');
+    }
+
+    function renderUrlList() {
+        const urls = readJSONList(STORAGE_URLS);
+        const list = document.getElementById('tm-url-list');
+        if (!list) return;
+        list.innerHTML = '';
+        if (!urls.length) {
+            list.innerHTML = `<div class="tm-item tm-meta">No package URLs configured.</div>`;
+            return;
+        }
+
+        urls.forEach((url) => {
+            const node = document.createElement('div');
+            node.className = 'tm-item';
+            node.innerHTML = `
+                <div style="word-break:break-word; font-size:0.78rem;">${url}</div>
+                <div class="tm-row" style="margin-top:8px;">
+                    <button class="tm-btn" data-tm-action="reload-url" data-url="${url}">Reload</button>
+                    <button class="tm-btn danger" data-tm-action="remove-url" data-url="${url}">Remove</button>
+                </div>
+            `;
+            list.appendChild(node);
+        });
+    }
+
+    function renderAutomataList() {
+        const listEl = document.getElementById('tm-automata-list');
+        if (!listEl) return;
+        const loader = window.automatonLoader;
+        const blacklist = readJSONList(STORAGE_BLACKLIST);
+        const automata = loader ? loader.listAll() : [];
+        const sortBy = document.getElementById('tm-sort')?.value || 'priority';
+        const conflicts = loader ? loader.getConflicts() : [];
+        const conflictNames = new Set(conflicts.flatMap(c => c.automata));
+
+        automata.sort((a, b) => {
+            if (sortBy === 'name') return a.name.localeCompare(b.name);
+            if (sortBy === 'source') return String(a.sourceUrl).localeCompare(String(b.sourceUrl));
+            return (a.priority ?? 100) - (b.priority ?? 100);
+        });
+
+        document.getElementById('tm-stat-loaded').textContent = String(automata.length);
+        document.getElementById('tm-stat-blacklisted').textContent = String(blacklist.length);
+        document.getElementById('tm-stat-packages').textContent = String(readJSONList(STORAGE_URLS).length);
+        document.getElementById('tm-stat-conflicts').textContent = String(conflicts.length);
+        document.getElementById('tm-live-count').textContent = `${automata.length} online`;
+
+        if (!automata.length) {
+            listEl.innerHTML = `<div class="tm-item tm-meta">No automata loaded.</div>`;
+            return;
+        }
+
+        listEl.innerHTML = '';
+        automata.forEach((a) => {
+            const blacklisted = blacklist.includes(a.name);
+            const item = document.createElement('div');
+            item.className = 'tm-item';
+            item.style.opacity = blacklisted ? '0.55' : '1';
+            item.innerHTML = `
+                <div style="display:flex; justify-content:space-between; gap:8px;">
+                    <div>
+                        <div>${a.name} <span class="tm-pill">v${a.version}</span>${conflictNames.has(a.name) ? '<span class="tm-pill" style="background:#5d341f;color:#ffceaa;">Conflict</span>' : ''}</div>
+                        <div class="tm-meta">priority: ${a.priority} | source: ${a.sourceUrl || 'unknown'}</div>
+                        <div class="tm-meta">${a.description || ''}</div>
+                        <div class="tm-meta">${formatMeta(a)}</div>
+                    </div>
+                </div>
+                <div class="tm-row" style="margin-top:8px;">
+                    <button class="tm-btn" data-tm-action="restart" data-name="${a.name}">Restart</button>
+                    <button class="tm-btn danger" data-tm-action="kill" data-name="${a.name}">Kill</button>
+                    <button class="tm-btn subtle" data-tm-action="toggle" data-name="${a.name}">
+                        ${blacklisted ? 'Enable' : 'Disable'}
+                    </button>
+                </div>
+            `;
+            listEl.appendChild(item);
+        });
+    }
+
+    async function refreshTaskManager(note) {
+        renderUrlList();
+        renderAutomataList();
+        if (note) tmLog(note);
+    }
+
+    window.toggleTaskManager = function(forceState) {
+        const sidebar = document.getElementById('task-manager-sidebar');
+        if (!sidebar) return;
+        const shouldOpen = typeof forceState === 'boolean' ? forceState : !sidebar.classList.contains('open');
+        sidebar.classList.toggle('open', shouldOpen);
+        if (shouldOpen) refreshTaskManager('Task manager opened');
+    };
+
+    window.taskManagerRefresh = async function() {
+        await refreshTaskManager('Status refreshed');
+    };
+
+    window.taskManagerAddUrl = async function() {
+        const input = document.getElementById('tm-new-url');
+        const url = input?.value?.trim();
+        if (!url) return;
+        const urls = readJSONList(STORAGE_URLS);
+        if (!urls.includes(url)) {
+            urls.push(url);
+            writeJSONList(STORAGE_URLS, urls);
+            tmLog(`Package URL added: ${url}`);
+        } else {
+            tmLog(`Package URL already exists: ${url}`);
+        }
+        if (input) input.value = '';
+        await window.taskManagerReloadAll();
+    };
+
+    window.taskManagerReloadAll = async function() {
+        if (!window.automatonLoader) return;
+        window.automatonLoader.setAutomataUrls(readJSONList(STORAGE_URLS));
+        window.automatonLoader.setBlacklist(readJSONList(STORAGE_BLACKLIST));
+        await window.automatonLoader.loadAll();
+        await refreshTaskManager('Reloaded package URLs');
+    };
+
+    window.taskManagerShutdownAll = async function() {
+        if (!window.automatonLoader) return;
+        const names = window.automatonLoader.list();
+        names.forEach((name) => window.automatonLoader.shutdown(name));
+        await refreshTaskManager(`Shutdown all automata (${names.length})`);
+    };
+
+    document.addEventListener('click', async (e) => {
+        const btn = e.target.closest('[data-tm-action]');
+        if (!btn || !window.automatonLoader) return;
+
+        const action = btn.getAttribute('data-tm-action');
+        const name = btn.getAttribute('data-name');
+        const url = btn.getAttribute('data-url');
+        const blacklist = readJSONList(STORAGE_BLACKLIST);
+        const urls = readJSONList(STORAGE_URLS);
+
+        if (action === 'restart' && name) {
+            await window.automatonLoader.restart(name);
+            tmLog(`Restarted ${name}`);
+        } else if (action === 'kill' && name) {
+            window.automatonLoader.kill(name);
+            tmLog(`Killed ${name}`);
+        } else if (action === 'toggle' && name) {
+            const idx = blacklist.indexOf(name);
+            if (idx >= 0) {
+                blacklist.splice(idx, 1);
+                writeJSONList(STORAGE_BLACKLIST, blacklist);
+                await window.automatonLoader.loadAll();
+                tmLog(`Enabled ${name}`);
+            } else {
+                blacklist.push(name);
+                writeJSONList(STORAGE_BLACKLIST, blacklist);
+                window.automatonLoader.setBlacklist(blacklist);
+                window.automatonLoader.kill(name);
+                tmLog(`Disabled ${name}`);
+            }
+        } else if (action === 'remove-url' && url) {
+            writeJSONList(STORAGE_URLS, urls.filter(u => u !== url));
+            tmLog(`Removed package URL: ${url}`);
+            await window.taskManagerReloadAll();
+            return;
+        } else if (action === 'reload-url' && url) {
+            await window.automatonLoader.loadPackage(url);
+            tmLog(`Reloaded package: ${url}`);
+        }
+
+        await refreshTaskManager();
+    });
+
+    window.on('automaton_loaded', (payload) => tmLog(`Loaded ${payload?.name || 'unknown'}`));
+    window.on('automaton_unloaded', (payload) => tmLog(`Unloaded ${payload?.name || 'unknown'} (${payload?.reason || 'n/a'})`));
+    window.on('error_occurred', (payload) => tmLog(`Error: ${payload?.message || 'unknown'}`));
+
     // 3. Automata Loader Integration
     async function initAkariAutomata() {
         if (typeof AutomatonLoader === 'undefined') {
@@ -217,6 +424,7 @@
         window.log('info', "Waking up the automata...");
         await loader.loadAll();
         console.log("Loaded automata:", loader.list());
+        refreshTaskManager('Automata initialized');
         
         setTimeout(() => {
             const overlay = document.getElementById('overlay');
@@ -297,6 +505,7 @@
                 window.automatonLoader.setBlacklist(bl);
                 await window.automatonLoader.loadAll();
                 respond({ action: 'automata_list', automata: window.automatonLoader.listAll() });
+                refreshTaskManager('Automata updated from settings');
             }
         }
         else if (e.data.action === 'automata_kill') {
@@ -304,12 +513,14 @@
                 window.automatonLoader.setBlacklist(JSON.parse(localStorage.getItem('akari:automata_blacklist') || '[]'));
                 window.automatonLoader.kill(e.data.name);
                 respond({ action: 'automata_list', automata: window.automatonLoader.listAll() });
+                refreshTaskManager(`Automaton killed from settings: ${e.data.name}`);
             }
         }
         else if (e.data.action === 'automata_restart') {
             if (window.automatonLoader) {
                 await window.automatonLoader.restart(e.data.name);
                 respond({ action: 'automata_list', automata: window.automatonLoader.listAll() });
+                refreshTaskManager(`Automaton restarted from settings: ${e.data.name}`);
             }
         }
         else if (e.data.action === 'apply_visuals') {


### PR DESCRIPTION
### Motivation
- Provide an in-app, real-time control surface so users can manage Automata without leaving the main WebUI. 
- Expose package management, per-automaton lifecycle controls, conflict visibility and an event log to simplify runtime operations.

### Description
- Added a Task Manager sidebar and opener button to `UI/WebUI/index.html` including styles, runtime stats, package URL controls, automata list, and event log. 
- Implemented full client-side task-manager logic in `UI/WebUI/index.js` for URL storage, rendering package and automata lists, per-automaton actions (`restart`, `kill`, `enable/disable` via blacklist), global actions (`refresh`, `reload all`, `shutdown all`), and a short runtime event log. 
- Integrated the task manager with the existing `AutomatonLoader` runtime and wired refresh hooks into iframe cross-window actions (`automata_update`, `automata_kill`, `automata_restart`) and automata lifecycle events so UI and settings stay synchronized. 
- Added lightweight localStorage helpers, conflict detection display, sorting options, and logging helpers to help administrators operate automata in real time. 

### Testing
- Ran a static JavaScript syntax check with `node --check UI/WebUI/index.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbc5ec15c8330bcc7b94bb4cc3e61)